### PR TITLE
Keep Screen On should honor wireless charging

### DIFF
--- a/src/com/android/settings/DevelopmentSettings.java
+++ b/src/com/android/settings/DevelopmentSettings.java
@@ -1200,7 +1200,8 @@ public class DevelopmentSettings extends RestrictedSettingsFragment
             Settings.Global.putInt(getActivity().getContentResolver(),
                     Settings.Global.STAY_ON_WHILE_PLUGGED_IN,
                     mKeepScreenOn.isChecked() ?
-                    (BatteryManager.BATTERY_PLUGGED_AC | BatteryManager.BATTERY_PLUGGED_USB) : 0);
+                    (BatteryManager.BATTERY_PLUGGED_AC | BatteryManager.BATTERY_PLUGGED_USB |
+                        BatteryManager.BATTERY_PLUGGED_WIRELESS) : 0);
         } else if (preference == mBtHciSnoopLog) {
             writeBtHciSnoopLogOptions();
         } else if (preference == mAllowMockLocation) {


### PR DESCRIPTION
Keep Screen On should honor wireless charging, in addition to AC and USB charging. The power service supports this already, but the UI here wasn't setting the flag.
