### PR TITLE
Fix poor translation

### DIFF
--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -2551,7 +2551,7 @@
     <string name="other_sound_settings" msgid="3151004537006844718">"Outros sons"</string>
     <string name="dial_pad_tones_title" msgid="1999293510400911558">"Tons do teclado"</string>
     <string name="screen_locking_sounds_title" msgid="1340569241625989837">"Sons de bloqueio de tela"</string>
-    <string name="charging_sounds_title" msgid="1132272552057504251">"Sons de cobrança"</string>
+    <string name="charging_sounds_title" msgid="1132272552057504251">"Sons de carregamento de bateria"</string>
     <string name="docking_sounds_title" msgid="155236288949940607">"Sons da dock"</string>
     <string name="touch_sounds_title" msgid="5326587106892390176">"Sons de toque"</string>
     <string name="vibrate_on_touch_title" msgid="674710566941697253">"Vibrar ao tocar"</string>


### PR DESCRIPTION
The current translation "cobrança" is related to money charging, not to power charging.
